### PR TITLE
Add modules used in adapters as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,30 @@
     "dependencies": {
         "detect-installed": "^2.0.4"
     },
+    "peerDependencies": {
+        "autoprefixer": "^9.5.1",
+        "babel-loader": "^8.0.5",
+        "clean-webpack-plugin": "^2.0.1",
+        "copy-webpack-plugin": "^5.0.2",
+        "css-loader": "^2.1.1",
+        "cssnano": "^4.1.10",
+        "eslint": "^5.16.0",
+        "eslint-loader": "^2.1.2",
+        "file-loader": "^3.0.1",
+        "jquery": "^3.4.0",
+        "mini-css-extract-plugin": "^0.6.0",
+        "postcss-loader": "^3.0.0",
+        "resolve-url-loader": "^3.1.0",
+        "sass-loader": "^7.1.0",
+        "stylelint": "^10.0.1",
+        "stylelint-bare-webpack-plugin": "^1.1.1",
+        "ts-loader": "^5.3.3",
+        "tslint-loader": "^3.5.4",
+        "typescript": "^3.4.4",
+        "uglifyjs-webpack-plugin": "^2.1.2",
+        "webpack": "^4.30.0",
+        "webpack-stats-plugin": "^0.2.1"
+    },
     "husky": {
         "hooks": {
             "pre-commit": "lint-staged"


### PR DESCRIPTION
@see #5 

...to make sure that, when a major version update occurs, and the project's installed modules do not match the peer dependencies, the npm module installation would fail.