### PR TITLE
Dont remove generated assets by minicss-extract-plugin in watch mode

### DIFF
--- a/lib/adapter/freshheads/CleanBuildDirectoryAdapter.ts
+++ b/lib/adapter/freshheads/CleanBuildDirectoryAdapter.ts
@@ -13,7 +13,9 @@ export default class CleanBuildDirectoryAdapter implements Adapter {
             webpackConfig.plugins = [];
         }
 
-        const pluginInstance: Plugin = new CleanWebpackPlugin();
+        const pluginInstance: Plugin = new CleanWebpackPlugin({
+            cleanStaleWebpackAssets: false
+        });
 
         webpackConfig.plugins.push(pluginInstance);
 


### PR DESCRIPTION
Work around for a bug in the clean-webpack-plugin: https://github.com/johnagan/clean-webpack-plugin/issues/159