### PR TITLE
use eval-source-map to speed up build times in development

### DIFF
--- a/lib/adapter/freshheads/SourcemapAdapter.ts
+++ b/lib/adapter/freshheads/SourcemapAdapter.ts
@@ -13,7 +13,7 @@ export default class SourcemapAdapter implements Adapter {
 
         const isDev = builderConfig.env !== Environment.Production;
 
-        webpackConfig.devtool = isDev ? 'inline-source-map' : 'source-map';
+        webpackConfig.devtool = isDev ? 'eval-source-map' : 'source-map';
 
         next();
     }


### PR DESCRIPTION
inline-source-map was not intended for development usage. Webpack recommends using eval-source-maps in development. This should give accurate line numbers but speeds up rebuilds. 

There are also other options if we want to speeds up initial build but this doesn't seem required.
https://webpack.js.org/configuration/devtool/