### PR TITLE
Changes to babel-loader config

### DIFF
--- a/lib/adapter/freshheads/BabelLoaderAdapter.ts
+++ b/lib/adapter/freshheads/BabelLoaderAdapter.ts
@@ -7,12 +7,10 @@ import { iterateObjectValues } from '../../utility/iterationHelper';
 
 export type Config = {
     include: string[];
-    babelConfigurationFilePath: string;
 };
 
 export const DEFAULT_CONFIG: Config = {
     include: [path.resolve(process.cwd(), 'src/js')],
-    babelConfigurationFilePath: path.resolve(process.cwd(), 'babel.config.js'),
 };
 
 export default class BabelLoaderAdapter implements Adapter {
@@ -47,8 +45,6 @@ export default class BabelLoaderAdapter implements Adapter {
                     options: {
                         // For performance @see https://github.com/babel/babel-loader#babel-loader-is-slow
                         cacheDirectory: true,
-
-                        configFile: this.config.babelConfigurationFilePath,
                     },
                 },
             ],

--- a/lib/adapter/freshheads/BabelLoaderAdapter.ts
+++ b/lib/adapter/freshheads/BabelLoaderAdapter.ts
@@ -7,10 +7,17 @@ import { iterateObjectValues } from '../../utility/iterationHelper';
 
 export type Config = {
     include: string[];
+    loaderOptions: {
+        cacheDirectory: boolean;
+        [key: string]: any;
+    };
 };
 
 export const DEFAULT_CONFIG: Config = {
     include: [path.resolve(process.cwd(), 'src/js')],
+    loaderOptions: {
+        cacheDirectory: true, // For performance @see https://github.com/babel/babel-loader#babel-loader-is-slow
+    }
 };
 
 export default class BabelLoaderAdapter implements Adapter {
@@ -42,10 +49,7 @@ export default class BabelLoaderAdapter implements Adapter {
             use: [
                 {
                     loader: 'babel-loader',
-                    options: {
-                        // For performance @see https://github.com/babel/babel-loader#babel-loader-is-slow
-                        cacheDirectory: true,
-                    },
+                    options: this.config.loaderOptions,
                 },
             ],
         };

--- a/tests/adapter/freshheads/BabelLoaderAdapter.test.js
+++ b/tests/adapter/freshheads/BabelLoaderAdapter.test.js
@@ -35,11 +35,9 @@ describe('FreshheadsBabelLoaderAdapter', () => {
 
         describe('..with custom settings', () => {
             it('should add the right rule to the webpack config', () => {
-                const custombabelConfigurationFilePath = './someOtherPath.json';
                 const customInclude = ['./someOtherPath.js'];
 
                 const adapter = new FreshheadsBabelLoaderAdapter({
-                    babelConfigurationFilePath: custombabelConfigurationFilePath,
                     include: customInclude,
                 });
 
@@ -68,10 +66,6 @@ describe('FreshheadsBabelLoaderAdapter', () => {
 
                 expect(onlyUse).toHaveProperty('loader', 'babel-loader');
                 expect(onlyUse).toHaveProperty('options');
-                expect(onlyUse.options).toHaveProperty(
-                    'configFile',
-                    custombabelConfigurationFilePath
-                );
             });
         });
 

--- a/tests/adapter/freshheads/BabelLoaderAdapter.test.js
+++ b/tests/adapter/freshheads/BabelLoaderAdapter.test.js
@@ -39,6 +39,9 @@ describe('FreshheadsBabelLoaderAdapter', () => {
 
                 const adapter = new FreshheadsBabelLoaderAdapter({
                     include: customInclude,
+                    loaderOptions: {
+                        rootMode: 'upward',
+                    },
                 });
 
                 const webpackConfig = {};
@@ -66,6 +69,7 @@ describe('FreshheadsBabelLoaderAdapter', () => {
 
                 expect(onlyUse).toHaveProperty('loader', 'babel-loader');
                 expect(onlyUse).toHaveProperty('options');
+                expect(onlyUse.options).toHaveProperty('rootMode', 'upward');
             });
         });
 

--- a/tests/adapter/freshheads/JavascriptAdapter.test.js
+++ b/tests/adapter/freshheads/JavascriptAdapter.test.js
@@ -4,12 +4,7 @@ const ProvidePlugin = require('webpack').ProvidePlugin;
 describe('FreshheadsJavascriptAdapter', () => {
     describe('Without customn configuration', () => {
         it('should set the correct defaults', () => {
-            const expectConfigFilePath = './babel.config.js';
-            const adapter = new FreshheadsJavascriptAdapter({
-                babelConfig: {
-                    babelConfigurationFilePath: expectConfigFilePath,
-                },
-            });
+            const adapter = new FreshheadsJavascriptAdapter();
             const webpackConfig = {};
 
             adapter.apply(webpackConfig, { env: 'dev' }, () => {});
@@ -36,20 +31,14 @@ describe('FreshheadsJavascriptAdapter', () => {
 
             expect(firstRuleOnlyUse).toHaveProperty('loader', 'babel-loader');
             expect(firstRuleOnlyUse).toHaveProperty('options');
-
-            const options = firstRuleOnlyUse.options;
-
-            expect(options).toHaveProperty('configFile', expectConfigFilePath);
         });
     });
 
     describe('With custom configuration', () => {
         it('should set the correct defaults', () => {
-            const expectedBabelConfigPath = './babel.config.js';
             const adapter = new FreshheadsJavascriptAdapter({
                 babelConfig: {
                     include: ['./test', './anders'],
-                    babelConfigurationFilePath: expectedBabelConfigPath,
                 },
                 jQuery: {
                     enabled: true,
@@ -84,13 +73,6 @@ describe('FreshheadsJavascriptAdapter', () => {
 
             expect(firstUse).toHaveProperty('loader', 'babel-loader');
             expect(firstUse).toHaveProperty('options');
-
-            const options = firstUse.options;
-
-            expect(options).toHaveProperty(
-                'configFile',
-                expectedBabelConfigPath
-            );
 
             const plugins = webpackConfig.plugins;
 

--- a/tests/adapter/freshheads/JavascriptAdapter.test.js
+++ b/tests/adapter/freshheads/JavascriptAdapter.test.js
@@ -2,7 +2,7 @@ const { FreshheadsJavascriptAdapter } = require('../../../build/index');
 const ProvidePlugin = require('webpack').ProvidePlugin;
 
 describe('FreshheadsJavascriptAdapter', () => {
-    describe('Without customn configuration', () => {
+    describe('Without custom configuration', () => {
         it('should set the correct defaults', () => {
             const adapter = new FreshheadsJavascriptAdapter();
             const webpackConfig = {};
@@ -39,6 +39,9 @@ describe('FreshheadsJavascriptAdapter', () => {
             const adapter = new FreshheadsJavascriptAdapter({
                 babelConfig: {
                     include: ['./test', './anders'],
+                    loaderOptions: {
+                        rootMode: 'upward',
+                    },
                 },
                 jQuery: {
                     enabled: true,
@@ -73,6 +76,12 @@ describe('FreshheadsJavascriptAdapter', () => {
 
             expect(firstUse).toHaveProperty('loader', 'babel-loader');
             expect(firstUse).toHaveProperty('options');
+
+            const options = firstUse.options;
+
+            expect(options).toHaveProperty('rootMode', 'upward');
+
+            expect(options).toHaveProperty('cacheDirectory', true);
 
             const plugins = webpackConfig.plugins;
 


### PR DESCRIPTION
Babel now recommends using .json files as config where possible instead of .js. This can be better cached + used by IDE. 

By not specifing the filename it will resolve any extension inside of the root (where webpack config is located) so this should be backwards compatible. But will allow us to move forward using this new standard.

For reference: https://babeljs.io/docs/en/config-files