### PR TITLE
simplify sonata admin adapter by no longer copying images with webpack

### DIFF
--- a/lib/adapter/freshheads/DefaultSonataAdminStackAdapter.ts
+++ b/lib/adapter/freshheads/DefaultSonataAdminStackAdapter.ts
@@ -31,25 +31,6 @@ const DEFAULT_CONFIG: RecursivePartial<DefaultStackConfig> = {
             'jquery-ui/ui/widget': 'blueimp-file-upload/js/vendor/jquery.ui.widget.js'
         },
     },
-    copyFilesToBuildDir: {
-        enabled: true,
-        // Copies assets from admin-bundle to build dir
-        additionalPatterns: [
-            {
-                from: path.resolve(
-                        process.cwd(),
-                        '../../vendor/freshheads/admin-bundle/Resources/public/assets/images/**/*'
-                ),
-                context: path.resolve(
-                    process.cwd(),
-                    '../../vendor/freshheads/admin-bundle/Resources/public/assets/'
-                ),
-                // admin bundle assets always get hashed also in dev environment
-                to: 'fhadmin/[path][name].[hash].[ext]',
-                toType: 'template',
-            },
-        ],
-    },
     javascript: {
         enabled: true,
         babelConfig: {


### PR DESCRIPTION
Zie ook pr op admin-bundle waar we hier nu geen gebruik meer van maken. Het gaat nog wel is mis omdat het vanuit een bundle moet komen. Ook voegt het niet zoveel toe om de 'login' images als enige via een hashed file op te halen.