### PR TITLE
enable svgo again because icons are still not visible so might as wel…

### DIFF
--- a/lib/adapter/freshheads/CssAdapter.ts
+++ b/lib/adapter/freshheads/CssAdapter.ts
@@ -65,8 +65,12 @@ export default class CssAdapter implements Adapter {
                     options: {
                         postcssOptions: () => {
                             // Adding custom plugins / options can be done at application level by adding a postcss.config.js
-                            // @todo you can not override settings with postcss.config file as loader settings are leading, find solution for this.
+                            // You can not override settings for the plugins loaded below because loader options are leading.
                             // @see https://github.com/webpack-contrib/postcss-loader#config
+
+                            // Autoprefixer requires settings to work with CSS grid in IE.
+                            // You can also trigger this by setting a comment
+                            // @see https://github.com/postcss/autoprefixer#grid-autoplacement-support-in-ie
                             const autoprefixer = require('autoprefixer');
 
                             const plugins = [
@@ -76,11 +80,8 @@ export default class CssAdapter implements Adapter {
                             ];
 
                             if (isProduction) {
-                                const cssNano = require('cssnano')({
-                                    preset: ['default', {
-                                        svgo: false, // disable svg optimalisations due to issue when xlink attributes are used.
-                                    }],
-                                });
+                                // css nano can be configured at application level by adding a cssnano.config.js
+                                const cssNano = require('cssnano');
 
                                 plugins.push(cssNano);
                             }


### PR DESCRIPTION
…l break build + explain how to change existing postcss settings

Issue #74 still exists but the previously supplied fix by disabling svgo doesn't make the icons work. It only prevents the build from crashing. But I guess it's better for it to crash so you can find the icon that uses xlink and is part of a spritemap than that is silently doesn't show the icons.