### PR TITLE
Renamed referenced files so the files can be used by webpack_asset ex…

### DIFF
--- a/lib/adapter/freshheads/LoadReferencedFilesAdapter.ts
+++ b/lib/adapter/freshheads/LoadReferencedFilesAdapter.ts
@@ -34,7 +34,10 @@ export default class LoadReferencedFilesAdapter implements Adapter {
 
         const rule: RuleSetRule = {
             test: this.config.test,
-            use: 'file-loader',
+            loader: 'file-loader',
+            options: {
+                name: '[name].[contenthash].[ext]',
+            },
         };
 
         if (typeof webpackConfig.module === 'undefined') {


### PR DESCRIPTION
…tension.

From now on, fonts can be preloaded in the following way:

`<link rel="preload" href="{{ webpack_asset('assets/frontend/build', 'gotham-light', 'woff2') }}" as="font">`