### PR TITLE
name must be included so assets can be used by webpack_asset twig ext…

### DIFF
--- a/lib/adapter/freshheads/LoadReferencedFilesAdapter.ts
+++ b/lib/adapter/freshheads/LoadReferencedFilesAdapter.ts
@@ -1,6 +1,6 @@
 import { Adapter, NextCallback } from '../Adapter';
 import { Configuration, RuleSetRule } from 'webpack';
-import { BuilderConfig, Environment } from '../../Builder';
+import { BuilderConfig } from '../../Builder';
 
 export type Config = {
     test: string | RegExp;
@@ -22,18 +22,15 @@ export default class LoadReferencedFilesAdapter implements Adapter {
 
     public apply(
         webpackConfig: Configuration,
-        builderConfig: BuilderConfig,
+        _builderConfig: BuilderConfig,
         next: NextCallback
     ) {
-        const isDevelopment = builderConfig.env === Environment.Dev;
-
         const rule: RuleSetRule = {
             test: this.config.test,
             type: 'asset/resource',
             generator: {
-                filename: isDevelopment
-                    ? '[name].[hash][ext][query]'
-                    : '[hash][ext][query]',
+                // name must be included so assets can be used by webpack_asset twig extension
+                filename: '[name].[hash][ext][query]',
             },
         };
 


### PR DESCRIPTION
…ension

Liep hier tegen aan toen het preloaden niet meer werkte van fonts. Dit hadden we in v3 ok al eens gefixed maar met de overgang naar webpack 5 en de asset modules is dit over het hoofd gezien.