### PR TITLE
stop forcing fibers dependency for sass as it doesn't work with node …

### DIFF
--- a/lib/adapter/freshheads/SassLoaderAdapter.ts
+++ b/lib/adapter/freshheads/SassLoaderAdapter.ts
@@ -72,7 +72,6 @@ export default class SassLoaderAdapter implements Adapter {
             'sass-loader': '12.0.0',
             'resolve-url-loader': '3.1.0',
             sass: '1.35.0',
-            fibers: '5.0.0',
         };
 
         iterateObjectValues<string>(requiredModules, (minVersion, module) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@freshheads/webpack-config-builder",
-            "version": "4.2.0",
+            "version": "4.2.1",
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.1",
@@ -26,7 +26,6 @@
                 "copy-webpack-plugin": "^9.0.1",
                 "css-loader": "^5.2.6",
                 "css-minimizer-webpack-plugin": "^3.0.2",
-                "fibers": "^5.0.0",
                 "husky": "^6.0.0",
                 "jest": "^26.6.3",
                 "jquery": "^3.6.0",
@@ -4246,18 +4245,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "dev": true,
-            "bin": {
-                "detect-libc": "bin/detect-libc.js"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/detect-newline": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -4944,19 +4931,6 @@
             "dev": true,
             "dependencies": {
                 "bser": "2.1.1"
-            }
-        },
-        "node_modules/fibers": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.1.tgz",
-            "integrity": "sha512-VMC7Frt87Oo0AOJ6EcPFbi+tZmkQ4tD85aatwyWL6I9cYMJmm2e+pXUJsfGZ36U7MffXtjou2XIiWJMtHriErw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "detect-libc": "^1.0.3"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/fill-range": {
@@ -13935,12 +13909,6 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
-        "detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "dev": true
-        },
         "detect-newline": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -14488,15 +14456,6 @@
             "dev": true,
             "requires": {
                 "bser": "2.1.1"
-            }
-        },
-        "fibers": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.1.tgz",
-            "integrity": "sha512-VMC7Frt87Oo0AOJ6EcPFbi+tZmkQ4tD85aatwyWL6I9cYMJmm2e+pXUJsfGZ36U7MffXtjou2XIiWJMtHriErw==",
-            "dev": true,
-            "requires": {
-                "detect-libc": "^1.0.3"
             }
         },
         "fill-range": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
         "copy-webpack-plugin": "^9.0.1",
         "css-loader": "^5.2.6",
         "css-minimizer-webpack-plugin": "^3.0.2",
-        "fibers": "^5.0.0",
         "husky": "^6.0.0",
         "jest": "^26.6.3",
         "jquery": "^3.6.0",


### PR DESCRIPTION
…16. For build speed it is still recommended for node 12 / 14

Note from author of Fibers:

> NOTE OF OBSOLESCENCE -- The author of this project recommends you avoid its use if possible. The original version of this module targeted nodejs v0.1.x in early 2011 when JavaScript on the server looked a lot different. Since then [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function), [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), and [Generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) were standardized and the ecosystem as a whole has moved in that direction.
> 
> I'll continue to support newer versions of nodejs as long as possible but v8 and nodejs are extraordinarily complex and dynamic platforms. It is inevitable that one day this library will abruptly stop working and no one will be able to do anything about it.
> 
> I'd like to say thank you to all the users of fibers, your support over the years has meant a lot to me.

> Update [April 13th, 2021] -- Fibers is not compatible with nodejs v16.0.0 or later. Unfortunately, v8 commit [dacc2fee0f](https://github.com/v8/v8/commit/dacc2fee0f815823782a7e432c79c2a7767a4765)[](https://github.com/laverdet/node-fibers#fibers1----fiber-support-for-v8-and-node) is a breaking change and workarounds are non-trivial.

Also some information from sass-loader:
https://sass-lang.com/blog/node-fibers-discontinued

I'm not sure how much performance is lost when building most of our sass based code. There is an alternative which is called embedded-sass. So we best just wait for this. Or stay on node 14 for the time being.