### PR TITLE
Ignore css order conflict

### DIFF
--- a/lib/adapter/freshheads/ExtractCssPluginAdapter.ts
+++ b/lib/adapter/freshheads/ExtractCssPluginAdapter.ts
@@ -40,6 +40,7 @@ export default class ExtractCssPluginAdapter implements Adapter {
         const plugin: WebpackPluginInstance = new MiniCssExtractPlugin({
             filename: isProduction ? '[name].[contenthash].css' : '[name].css',
             chunkFilename: isProduction ? '[id].[contenthash].css' : '[id].css',
+            ignoreOrder: false, // Because we use CSS modules or BEM naming convention, we can safely ignore the order conflict warnings
         });
 
         webpackConfig.plugins.push(plugin);

--- a/tests/adapter/freshheads/SourcemapAdapter.test.js
+++ b/tests/adapter/freshheads/SourcemapAdapter.test.js
@@ -10,7 +10,11 @@ describe('FreshheadsSourcemapAdapter', () => {
             const adapter = new FreshheadsSourcemapAdapter();
             const webpackConfig = {};
 
-            adapter.apply(webpackConfig, { env: 'production' }, () => {});
+            adapter.apply(
+                webpackConfig,
+                { env: 'production', sourceMap: true },
+                () => {}
+            );
 
             expect(webpackConfig).toEqual({
                 devtool: 'source-map',
@@ -23,7 +27,11 @@ describe('FreshheadsSourcemapAdapter', () => {
             const adapter = new FreshheadsSourcemapAdapter();
             const webpackConfig = {};
 
-            adapter.apply(webpackConfig, { env: 'dev' }, () => {});
+            adapter.apply(
+                webpackConfig,
+                { env: 'dev', sourceMap: true },
+                () => {}
+            );
 
             expect(webpackConfig).toEqual({
                 devtool: 'eval-source-map',


### PR DESCRIPTION
Het gaat om deze conflict warnings: 

```
WARNING in chunk src_js_components_dashboard_chapterOverview_ChapterOverview_tsx-src_js_components_dashboard_c-cd9dbc [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./node_modules/resolve-url-loader/index.js??ruleSet[1].rules[2].use[0]!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[2].use[1]!./src/js/components/dashboard/shared/announcement/announcement.module.scss
despite it was not able to fulfill desired ordering with these modules:
 * css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./node_modules/resolve-url-loader/index.js??ruleSet[1].rules[2].use[0]!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[2].use[1]!./src/js/components/dashboard/userDashboard/components/UserDashboardUserInformation.module.scss
   - couldn't fulfill desired order of chunk group(s) dashboard_paragraph_detail
   - while fulfilling desired order of chunk group(s) dashboard_user_dashboard
```

Dit is alleen een probleem wanneer het om globale css zou gaan. Wij zullen dit sowieso niet snel importeren in javascript, en als dit wel het geval is dan mag je ervan uit gaan de rest van het project wel css bevat die ofwel scoped is met een css module of een naming convetion als BEM gebruikt waardoor het niet willekeurig iets anders kan overschrijven omdat de volgorde aanpast bij het builden. Daarnaast zal een library die een globale css aanbied ook vaak wel een prefix in de classnames gebruiken.

Door deze optie toe te voegen gaan de warnings weg. Het is namelijk zelf niet goed te controleren wanneer componenten samengevoegd worden in 1 javascript bestand waardoor de css mogelijk op andere volgorde geïmporteerd word.

https://webpack.js.org/plugins/mini-css-extract-plugin/#remove-order-warnings

Sidenote:

Dit is mogelijk wel gerelateerd aan het probleem waar NextJs met Mantine tegen aanloopt. Dus als je een UI framework in je entry JS bestand importeert zou het zomaar kunnen zijn dat die volgorde nog aangepast word. Next.JS zal deze warnings ook wel uit hebben staan waardoor het niet opviel.